### PR TITLE
SharingGRDB Trait

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "448cc39ae7f869384746dbb7a52a7af95bfd8eb43e707c4555298a4df2e163a4",
+  "originHash" : "2f36f5506aff7014c7948279f4abaf84f38af1e99cebaeff9afb881ad7cc7687",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -20,12 +20,29 @@
       }
     },
     {
+      "identity" : "sharing-grdb-icloud",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/sharing-grdb-icloud",
+      "state" : {
+        "revision" : "f3a9c5a3c0942b9e8056736b3994ac07b381ea6c"
+      }
+    },
+    {
       "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
         "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
         "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {
@@ -74,6 +91,33 @@
       }
     },
     {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "75e846ee3159dc75b3a29bfc24b6ce5a557ddca9",
+        "version" : "2.5.2"
+      }
+    },
+    {
       "identity" : "swift-snapshot-testing",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
@@ -87,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "efd928f9f1c5bee4356a5d8a9a8e862ce4abb8a3",
-        "version" : "0.8.1"
+        "branch" : "main",
+        "revision" : "2d9f1d94f5cbfbd37c5ab0b2500b385db95516a3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,15 @@ let package = Package(
         """
     ),
     .trait(
+      name: "SwiftUUIDV7SharingGRDB",
+      description: """
+        Conforms UUIDV7 to IdentifierStringConvertible to make it compatible with CloudKit sync.
+
+        This trait also enables SwiftUUIDV7GRDB.
+        """,
+      enabledTraits: ["SwiftUUIDV7GRDB"]
+    ),
+    .trait(
       name: "SwiftUUIDV7Dependencies",
       description:
         """
@@ -38,7 +47,11 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-tagged", from: "0.10.0"),
     .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.8.1"),
     .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.9.2"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0")
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+    .package(
+      url: "https://github.com/pointfreeco/sharing-grdb-icloud",
+      revision: "f3a9c5a3c0942b9e8056736b3994ac07b381ea6c"
+    )
   ],
   targets: [
     .target(
@@ -63,6 +76,11 @@ let package = Package(
           name: "Dependencies",
           package: "swift-dependencies",
           condition: .when(traits: ["SwiftUUIDV7Dependencies"])
+        ),
+        .product(
+          name: "SharingGRDBCore",
+          package: "sharing-grdb-icloud",
+          condition: .when(traits: ["SwiftUUIDV7SharingGRDB"])
         )
       ]
     ),

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ assert(id2 > id1) // No longer true 100% of the time.
 ## Library Integrations
 The library ships with UUID v7 support to popular libraries in the ecosystem, each behind a package trait.
 
-- [Tagged](https://github.com/pointfreeco/swift-tagged) (
+- [Tagged](https://github.com/pointfreeco/swift-tagged)
   - **Trait:** `SwiftUUIDV7Tagged`
   - Adds convenience initializers to `Tagged` that support `UUIDV7` generations.
-- [GRDB](https://github.com/groue/GRDB.swift) (
+- [GRDB](https://github.com/groue/GRDB.swift)
   - **Trait:** `SwiftUUIDV7GRDB`
   - Adds `DatabaseValueConvertible` and `StatementColumnConvertible` conformances to `UUIDV7`.
   - Adds `DatabaseFunction` instances for generating, parsing, and extracting properties from `UUIDV7`.
-- [StructuredQueries](https://github.com/pointfreeco/swift-structured-queries) (
+- [StructuredQueries](https://github.com/pointfreeco/swift-structured-queries)
   - **Trait:** `SwiftUUIDV7StructuredQueries`
   - Adds a `QueryBindable` conformance to `UUIDV7`.
   - Adds `UUIDV7.BytesRepresentation` and `UUIDV7.UppercaseRepresentation` column representations of `UUIDV7`.
@@ -80,6 +80,10 @@ The library ships with UUID v7 support to popular libraries in the ecosystem, ea
   - **Trait:** `SwiftUUIDV7Dependencies`
   - Adds a `UUIDV7Generator` dependency.
   - Adds an initializer to `UUIDGenerator` that generates `UUIDV7` instances under the hood.
+- [SharingGRDB](https://github.com/pointfreeco/sharing-grdb)
+  - **Trait:** `SwiftUUIDV7SharingGRDB`
+  - Conforms UUIDV7 to `IdentifierStringConvertible` to make it compatible with CloudKit sync.
+  - This trait also enables `SwiftUUIDV7GRDB`.
 
 Additionally, `UUIDV7` conforms to `EntityIdentifierConvertible` from AppIntents, which is available without a need to specify a trait when building for Apple platforms.
 

--- a/Sources/UUIDV7/UUIDV7+SharingGRDB.swift
+++ b/Sources/UUIDV7/UUIDV7+SharingGRDB.swift
@@ -1,0 +1,11 @@
+#if SwiftUUIDV7SharingGRDB
+  import SharingGRDBCore
+
+  extension UUIDV7: IdentifierStringConvertible {
+    public var rawIdentifier: String { self.uuidString }
+
+    public init?(rawIdentifier: String) {
+      self.init(uuidString: rawIdentifier)
+    }
+  }
+#endif


### PR DESCRIPTION
Adds a `UUIDV7` conformance to `IdentifierStringConvertible` from Sharing GRDB iCloud.

Will merge once Sharing GRDB iCloud is released publicly.