### PR TITLE
Underscore systemNow Date init

### DIFF
--- a/Sources/UUIDV7/UUIDV7.swift
+++ b/Sources/UUIDV7/UUIDV7.swift
@@ -145,8 +145,8 @@ extension UUIDV7 {
 
 #if canImport(Foundation)
   extension UUIDV7 {
-    package init(systemNow: Date) {
-      self.init(systemNow: systemNow.timeIntervalSince1970)
+    package init(_systemNow: Date) {
+      self.init(systemNow: _systemNow.timeIntervalSince1970)
     }
   }
 #endif

--- a/Tests/UUIDV7Tests/UUIDV7Tests.swift
+++ b/Tests/UUIDV7Tests/UUIDV7Tests.swift
@@ -184,9 +184,9 @@
     @Test("Monotonically Increases when System Time is Moved Backwards")
     func monotonicallyIncreasingWhenBackwards() async throws {
       let date = Date()
-      let u1 = UUIDV7(systemNow: date)
-      let u2 = UUIDV7(systemNow: date - 1000)
-      let u3 = UUIDV7(systemNow: date - 2000)
+      let u1 = UUIDV7(_systemNow: date)
+      let u2 = UUIDV7(_systemNow: date - 1000)
+      let u3 = UUIDV7(_systemNow: date - 2000)
       #expect(u3 > u2)
       #expect(u2 > u1)
       #expect(u1 < u2)
@@ -196,10 +196,10 @@
     @Test("Monotonically Increases when System Time Fluctuates")
     func monotonicallyIncreasingWhenFluctuating() async throws {
       let date = Date()
-      var u1 = UUIDV7(systemNow: date)
+      var u1 = UUIDV7(_systemNow: date)
       for i in 0..<1000 {
         let interval = TimeInterval(i.isMultiple(of: 2) ? -i : i)
-        let u2 = UUIDV7(systemNow: date + interval)
+        let u2 = UUIDV7(_systemNow: date + interval)
         #expect(u2 > u1)
         #expect(u1 < u2)
         u1 = u2
@@ -209,15 +209,15 @@
     @Test("Monotonically Increases when Jump in System Time")
     func monotonicallyIncreasesWhenJump() async throws {
       let date = Date()
-      var u1 = UUIDV7(systemNow: date)
+      var u1 = UUIDV7(_systemNow: date)
       for i in 0..<1000 {
-        let u2 = UUIDV7(systemNow: date - TimeInterval(i))
+        let u2 = UUIDV7(_systemNow: date - TimeInterval(i))
         #expect(u2 > u1)
         #expect(u1 < u2)
         u1 = u2
       }
       for i in 1000..<2000 {
-        let u2 = UUIDV7(systemNow: date + TimeInterval(i))
+        let u2 = UUIDV7(_systemNow: date + TimeInterval(i))
         #expect(u2 > u1)
         #expect(u1 < u2)
         u1 = u2


### PR DESCRIPTION
Since it's encouraged to copy paste `UUIDV7.swift` directly into a project, this means that any `package` access-level APIs would now become accessible within that project all of a sudden.

The `systemNow` init that takes a date was only made package accessible for testing obscure monotonicity behavior, and should now be called at the application level even though it is accessible.  Therefore, we'll discourage its use with an underscore.